### PR TITLE
Implement deliver-once by checking request IDs against a cache

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,8 +20,9 @@ var What = "dnsimple-strillone"
 var Version string
 
 const (
-	dnsimpleURL = "https://dnsimple.com"
-	cacheTTL    = 300
+	dnsimpleURL            = "https://dnsimple.com"
+	cacheTTL               = 300
+	headerProcessingStatus = "X-Processing-Status"
 )
 
 var (
@@ -105,7 +106,7 @@ func (s *Server) Slack(w http.ResponseWriter, r *http.Request, params httprouter
 	_, cacheExists := processedEvents.Get(event.EventHeader().RequestID)
 	if cacheExists {
 		log.Printf("Skipping event %v as already processed\n", event.EventHeader().RequestID)
-		w.Header().Set("X-Status", "skipped;already-processed")
+		w.Header().Set(headerProcessingStatus, "skipped;already-processed")
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -104,7 +104,8 @@ func (s *Server) Slack(w http.ResponseWriter, r *http.Request, params httprouter
 	// Check if the event was already processed
 	_, cacheExists := processedEvents.Get(event.EventHeader().RequestID)
 	if cacheExists {
-		log.Printf("Event %v already processed, skipping\n", event.EventHeader().RequestID)
+		log.Printf("Skipping event %v as already processed\n", event.EventHeader().RequestID)
+		w.Header().Set("X-Status", "skipped;already-processed")
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -48,3 +48,19 @@ func TestSlack(t *testing.T) {
 		t.Errorf("POST /slack expected response\n\t%v\ngot\n\t%v", want, got)
 	}
 }
+
+func TestSlackTwice(t *testing.T) {
+	payload := `{"data": {"domain": {"id": 1, "name": "example.com", "state": "hosted", "token": "domain-token", "account_id": 1010, "auto_renew": false, "created_at": "2016-02-07T14:46:29.142Z", "expires_on": null, "updated_at": "2016-02-07T14:46:29.142Z", "unicode_name": "example.com", "private_whois": false, "registrant_id": null}}, "actor": {"id": "1", "entity": "user", "pretty": "example@example.com"}, "account": {"id": 1010, "display": "User", "identifier": "user"}, "name": "domain.create", "api_version": "v2", "request_identifier": "096bfc29-2bf0-40c6-991b-f03b1f8521f1"}`
+
+	request, _ := http.NewRequest("POST", "/slack/-/-/-", strings.NewReader(payload))
+	response := httptest.NewRecorder()
+
+	server.Slack(response, request, httprouter.Params{})
+
+	server.Slack(response, request, httprouter.Params{})
+
+	if want := http.StatusOK; want != response.Code {
+		t.Errorf("POST /slack expected HTTP %v, got %v", want, response.Code)
+	}
+
+}

--- a/server_test.go
+++ b/server_test.go
@@ -60,8 +60,8 @@ func TestSlackTwice(t *testing.T) {
 	if want := http.StatusOK; want != response.Code {
 		t.Errorf("POST /slack expected HTTP %v, got %v", want, response.Code)
 	}
-	if want, got := "", response.Header().Get("X-Status"); want != got {
-		t.Errorf("POST /slack X-Status expected empty, got %v", got)
+	if want, got := "", response.Header().Get(headerProcessingStatus); want != got {
+		t.Errorf("POST /slack X-Processing-Status expected empty, got %v", got)
 	}
 
 	requestDuplicate, _ := http.NewRequest("POST", "/slack/-/-/-", strings.NewReader(payload))
@@ -72,7 +72,7 @@ func TestSlackTwice(t *testing.T) {
 	if want := http.StatusOK; want != responseDuplicate.Code {
 		t.Errorf("POST /slack (duplicate) expected HTTP %v, got %v", want, responseDuplicate.Code)
 	}
-	if want, got := "skipped;already-processed", responseDuplicate.Header().Get("X-Status"); want != got {
-		t.Errorf("POST /slack (duplicate) X-Status expected %v, got %v", want, got)
+	if want, got := "skipped;already-processed", responseDuplicate.Header().Get(headerProcessingStatus); want != got {
+		t.Errorf("POST /slack (duplicate) X-Processing-Status expected %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
This PR adds a cache with a TTL that is used to track request IDs that are processed. If a request ID is processed, it will not be processed again.