### PR TITLE
Support account membership events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.12
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079
-	github.com/dnsimple/dnsimple-go v0.40.1-0.20200430162822-abe42413c3c3
+	github.com/dnsimple/dnsimple-go v0.63.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/wunderlist/ttlcache v0.0.0-20180801091818-7dbceb0d5094
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079 h1:dm7wU6Dyf+rVGryOAB
 github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079/go.mod h1:W679Ri2W93VLD8cVpEY/zLH1ow4zhJcCyjzrKxfM3QM=
 github.com/dnsimple/dnsimple-go v0.40.1-0.20200430162822-abe42413c3c3 h1:NIdCy8yXoVnKklMRkD92KFnI68BAhp/Bu21DBn+si+A=
 github.com/dnsimple/dnsimple-go v0.40.1-0.20200430162822-abe42413c3c3/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
+github.com/dnsimple/dnsimple-go v0.63.0 h1:0doY8VW/ckRIMTmOw4E1vwqo+bhtjDzvh1pU2ZteFGA=
+github.com/dnsimple/dnsimple-go v0.63.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/message.go
+++ b/message.go
@@ -19,11 +19,11 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 		membersLink := s.FormatLink(fmt.Sprintf("%d", invitation.AccountID), fmtURL("/a/%d/account/members", invitation.AccountID))
 		switch e.Name {
 		case "account.user_invite":
-			text = fmt.Sprintf("%s invited %s to account %s", account.Email, invitation.Email, membersLink)
+			text = fmt.Sprintf("%s invited %s to account %s", e.Actor.Pretty, invitation.Email, membersLink)
 		case "account.user_invitation_accept":
-			text = fmt.Sprintf("%s accepted invitation to account %s", invitation.Email, membersLink)
+			text = fmt.Sprintf("%s accepted invitation to account %s", e.Actor.Pretty, membersLink)
 		case "account.user_invitation_revoke":
-			text = fmt.Sprintf("%s rejected invitation to account %s", invitation.Email, membersLink)
+			text = fmt.Sprintf("%s rejected invitation to account %s", e.Actor.Pretty, membersLink)
 		default:
 			text = fmt.Sprintf("%s performed %s", prefix, e.Name)
 		}

--- a/message.go
+++ b/message.go
@@ -16,7 +16,7 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 	case *webhook.AccountMembershipEventData:
 		account := data.Account
 		invitation := data.AccountInvitation
-		membersLink := s.FormatLink(fmt.Sprintf("%d", invitation.AccountID), fmtURL("/a/%d/account/members", invitation.AccountID))
+		membersLink := s.FormatLink(fmt.Sprintf("%d", account.ID), fmtURL("/a/%d/account/members", account.ID))
 		switch e.Name {
 		case "account.user_invite":
 			text = fmt.Sprintf("%s invited %s to account %s", e.Actor.Pretty, invitation.Email, membersLink)

--- a/message.go
+++ b/message.go
@@ -17,7 +17,14 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 		account := data.Account
 		invitation := data.AccountInvitation
 		membersLink := s.FormatLink(fmt.Sprintf("%d", invitation.AccountID), fmtURL("/a/%d/account/members", invitation.AccountID))
-		text = fmt.Sprintf("%s invited %s to account %s", account.Email, invitation.Email, membersLink)
+		switch e.Name {
+		case "account.user_invite":
+			text = fmt.Sprintf("%s invited %s to account %s", account.Email, invitation.Email, membersLink)
+		case "account.user_invitation_accept":
+			text = fmt.Sprintf("%s accepted invitation to account %s", invitation.Email, membersLink)
+		default:
+			text = fmt.Sprintf("%s performed %s", prefix, e.Name)
+		}
 	case *webhook.CertificateEventData:
 		certificate := data.Certificate
 		certificateDisplay := certificate.CommonName

--- a/message.go
+++ b/message.go
@@ -13,6 +13,11 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 	prefix := fmt.Sprintf("[%v] %v", s.FormatLink(account.Display, fmtURL("/a/%d/account", account.ID)), e.Actor.Pretty)
 
 	switch data := e.GetData().(type) {
+	case *webhook.AccountMembershipEventData:
+		account := data.Account
+		invitation := data.AccountInvitation
+		membersLink := s.FormatLink(fmt.Sprintf("%d", invitation.AccountID), fmtURL("/a/%d/account/members", invitation.AccountID))
+		text = fmt.Sprintf("%s invited %s to account %s", account.Email, invitation.Email, membersLink)
 	case *webhook.CertificateEventData:
 		certificate := data.Certificate
 		certificateDisplay := certificate.CommonName

--- a/message.go
+++ b/message.go
@@ -24,6 +24,8 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 			text = fmt.Sprintf("%s accepted invitation to account %s", e.Actor.Pretty, membersLink)
 		case "account.user_invitation_revoke":
 			text = fmt.Sprintf("%s rejected invitation to account %s", e.Actor.Pretty, membersLink)
+		case "account.user_remove":
+			text = fmt.Sprintf("%s removed %s from account %s", e.Actor.Pretty, data.User.Email, membersLink)
 		default:
 			text = fmt.Sprintf("%s performed %s", prefix, e.Name)
 		}

--- a/message.go
+++ b/message.go
@@ -22,6 +22,8 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 			text = fmt.Sprintf("%s invited %s to account %s", account.Email, invitation.Email, membersLink)
 		case "account.user_invitation_accept":
 			text = fmt.Sprintf("%s accepted invitation to account %s", invitation.Email, membersLink)
+		case "account.user_invitation_revoke":
+			text = fmt.Sprintf("%s rejected invitation to account %s", invitation.Email, membersLink)
 		default:
 			text = fmt.Sprintf("%s performed %s", prefix, e.Name)
 		}

--- a/message.go
+++ b/message.go
@@ -14,12 +14,10 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 
 	switch data := e.GetData().(type) {
 	case *webhook.AccountMembershipEventData:
-		account := data.Account
-		invitation := data.AccountInvitation
-		membersLink := s.FormatLink(fmt.Sprintf("%d", account.ID), fmtURL("/a/%d/account/members", account.ID))
+		membersLink := s.FormatLink(fmt.Sprintf("%d", data.Account.ID), fmtURL("/a/%d/account/members", data.Account.ID))
 		switch e.Name {
 		case "account.user_invite":
-			text = fmt.Sprintf("%s invited %s to account %s", e.Actor.Pretty, invitation.Email, membersLink)
+			text = fmt.Sprintf("%s invited %s to account %s", e.Actor.Pretty, data.AccountInvitation.Email, membersLink)
 		case "account.user_invitation_accept":
 			text = fmt.Sprintf("%s accepted invitation to account %s", e.Actor.Pretty, membersLink)
 		case "account.user_invitation_revoke":

--- a/message_test.go
+++ b/message_test.go
@@ -112,6 +112,35 @@ func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
 	}
 }
 
+func Test_Message_AccountUserRemoveEvent(t *testing.T) {
+	service := NewTestMessagingService("dummyMessagingService")
+	payload := `{
+    "name":"account.user_remove",
+    "actor": {"pretty": "john.doe@email.com"},
+    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+    "data":{
+      "user":{
+         "id":1120,
+         "email":"jane.doe@email.com"
+      },
+      "account":{
+         "id":12345,
+         "email":"john.doe@email.com"
+      }
+    }
+  }`
+	event, err := webhook.ParseEvent([]byte(payload))
+	if err != nil {
+		t.Fatalf("Error parsing: %v.\n%v", err, payload)
+	}
+
+	result := Message(service, event)
+
+	if want, got := "john.doe@email.com removed jane.doe@email.com from account <12345|https://dnsimple.com/a/12345/account/members>", result; want != got {
+		t.Fatalf("Expected '%v', got '%v'", want, got)
+	}
+}
+
 func Test_Message_DefaultMessage(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	account := webhook.Account{Identifier: "ID", Display: "john.doe@gmail.com"}

--- a/message_test.go
+++ b/message_test.go
@@ -25,7 +25,7 @@ func Test_Message_AccountUserInviteEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
     "name": "account.user_invite",
-    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "actor": {"pretty": "john.doe@email.com"},
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data": {
       "account": {
@@ -53,7 +53,7 @@ func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
     "name":"account.user_invitation_accept",
-    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "actor": {"pretty": "jane.doe@email.com"},
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data":{
       "account":{
@@ -83,7 +83,7 @@ func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
     "name":"account.user_invitation_revoke",
-    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "actor": {"pretty": "jane.doe@email.com"},
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data":{
       "account":{

--- a/message_test.go
+++ b/message_test.go
@@ -1,7 +1,7 @@
 package strillone
 
 import (
-  "fmt"
+	"fmt"
 	"testing"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
@@ -19,6 +19,34 @@ func (*TestMessagingService) FormatLink(url, name string) string {
 }
 func (*TestMessagingService) PostEvent(event *webhook.Event) (string, error) {
 	return "ok", nil
+}
+
+func Test_Message_AccountUserInviteEvent(t *testing.T) {
+	service := NewTestMessagingService("dummyMessagingService")
+	payload := `{
+    "name": "account.user_invite",
+    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+    "data": {
+      "account": {
+        "email": "john.doe@email.com"
+      },
+      "account_invitation": {
+        "email": "jane.doe@email.com",
+        "account_id": 12345
+      }
+    }
+  }`
+	event, err := webhook.ParseEvent([]byte(payload))
+	if err != nil {
+		t.Fatalf("Error parsing: %v.\n%v", err, payload)
+	}
+
+	result := Message(service, event)
+
+	if want, got := "john.doe@email.com invited jane.doe@email.com to account <12345|https://dnsimple.com/a/12345/account/members>", result; want != got {
+		t.Fatalf("Expected '%v', got '%v'", want, got)
+	}
 }
 
 func Test_Message_DefaultMessage(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -79,6 +79,36 @@ func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
 	}
 }
 
+func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
+	service := NewTestMessagingService("dummyMessagingService")
+	payload := `{
+    "name":"account.user_invitation_revoke",
+    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+    "data":{
+      "account":{
+        "email":"john.doe@email.com"
+      },
+      "account_invitation":{
+        "email":"jane.doe@email.com",
+        "account_id":12345,
+        "invitation_sent_at":"2020-05-12T18:42:44Z",
+        "invitation_accepted_at":null
+      }
+    }
+  }`
+	event, err := webhook.ParseEvent([]byte(payload))
+	if err != nil {
+		t.Fatalf("Error parsing: %v.\n%v", err, payload)
+	}
+
+	result := Message(service, event)
+
+	if want, got := "jane.doe@email.com rejected invitation to account <12345|https://dnsimple.com/a/12345/account/members>", result; want != got {
+		t.Fatalf("Expected '%v', got '%v'", want, got)
+	}
+}
+
 func Test_Message_DefaultMessage(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	account := webhook.Account{Identifier: "ID", Display: "john.doe@gmail.com"}

--- a/message_test.go
+++ b/message_test.go
@@ -1,8 +1,38 @@
 package strillone
 
 import (
+  "fmt"
 	"testing"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
 )
+
+type TestMessagingService struct {
+	Name string
+}
+
+func NewTestMessagingService(name string) *TestMessagingService {
+	return &TestMessagingService{Name: name}
+}
+func (*TestMessagingService) FormatLink(url, name string) string {
+	return fmt.Sprintf("<%s|%s>", url, name)
+}
+func (*TestMessagingService) PostEvent(event *webhook.Event) (string, error) {
+	return "ok", nil
+}
+
+func Test_Message_DefaultMessage(t *testing.T) {
+	service := NewTestMessagingService("dummyMessagingService")
+	account := webhook.Account{Identifier: "ID", Display: "john.doe@gmail.com"}
+	actor := webhook.Actor{Pretty: "john.doe@email.com"}
+	event := webhook.Event{Actor: &actor, Account: &account, Name: "event.name"}
+
+	result := Message(service, &event)
+
+	if want, got := "[<john.doe@gmail.com|https://dnsimple.com/a/0/account>] john.doe@email.com performed event.name", result; want != got {
+		t.Fatalf("Expected %v, got %v", want, got)
+	}
+}
 
 func Test_fmtURL(t *testing.T) {
 	if want, got := "https://dnsimple.com/a/1010/domains/1", fmtURL("/a/%v/domains/%v", "1010", 1); want != got {

--- a/message_test.go
+++ b/message_test.go
@@ -24,20 +24,20 @@ func (*TestMessagingService) PostEvent(event *webhook.Event) (string, error) {
 func Test_Message_AccountUserInviteEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
-    "name": "account.user_invite",
-    "actor": {"pretty": "john.doe@email.com"},
-    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
-    "data": {
-      "account": {
-        "id": 12345,
-        "email": "john.doe@email.com"
-      },
-      "account_invitation": {
-        "email": "jane.doe@email.com",
-        "account_id": 12345
-      }
-    }
-  }`
+		"name": "account.user_invite",
+		"actor": {"pretty": "john.doe@email.com"},
+		"account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+		"data": {
+			"account": {
+				"id": 12345,
+				"email": "john.doe@email.com"
+			},
+			"account_invitation": {
+				"email": "jane.doe@email.com",
+				"account_id": 12345
+			}
+		}
+	}`
 	event, err := webhook.ParseEvent([]byte(payload))
 	if err != nil {
 		t.Fatalf("Error parsing: %v.\n%v", err, payload)
@@ -53,22 +53,22 @@ func Test_Message_AccountUserInviteEvent(t *testing.T) {
 func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
-    "name":"account.user_invitation_accept",
-    "actor": {"pretty": "jane.doe@email.com"},
-    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
-    "data":{
-      "account":{
-        "id": 12345,
-        "email":"john.doe@email.com"
-      },
-      "account_invitation":{
-        "email":"jane.doe@email.com",
-        "account_id":12345,
-        "invitation_sent_at":"2020-05-12T18:42:44Z",
-        "invitation_accepted_at":"2020-05-12T18:43:44Z"
-      }
-    }
-  }`
+		"name":"account.user_invitation_accept",
+		"actor": {"pretty": "jane.doe@email.com"},
+		"account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+		"data":{
+			"account":{
+				"id": 12345,
+				"email":"john.doe@email.com"
+			},
+			"account_invitation":{
+				"email":"jane.doe@email.com",
+				"account_id":12345,
+				"invitation_sent_at":"2020-05-12T18:42:44Z",
+				"invitation_accepted_at":"2020-05-12T18:43:44Z"
+			}
+		}
+	}`
 	event, err := webhook.ParseEvent([]byte(payload))
 	if err != nil {
 		t.Fatalf("Error parsing: %v.\n%v", err, payload)
@@ -84,22 +84,22 @@ func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
 func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
-    "name":"account.user_invitation_revoke",
-    "actor": {"pretty": "jane.doe@email.com"},
-    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
-    "data":{
-      "account":{
-        "id": 12345,
-        "email":"john.doe@email.com"
-      },
-      "account_invitation":{
-        "email":"jane.doe@email.com",
-        "account_id":12345,
-        "invitation_sent_at":"2020-05-12T18:42:44Z",
-        "invitation_accepted_at":null
-      }
-    }
-  }`
+		"name":"account.user_invitation_revoke",
+		"actor": {"pretty": "jane.doe@email.com"},
+		"account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+		"data":{
+			"account":{
+				"id": 12345,
+				"email":"john.doe@email.com"
+			},
+			"account_invitation":{
+				"email":"jane.doe@email.com",
+				"account_id":12345,
+				"invitation_sent_at":"2020-05-12T18:42:44Z",
+				"invitation_accepted_at":null
+			}
+		}
+	}`
 	event, err := webhook.ParseEvent([]byte(payload))
 	if err != nil {
 		t.Fatalf("Error parsing: %v.\n%v", err, payload)
@@ -115,20 +115,20 @@ func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
 func Test_Message_AccountUserRemoveEvent(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	payload := `{
-    "name":"account.user_remove",
-    "actor": {"pretty": "john.doe@email.com"},
-    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
-    "data":{
-      "user":{
-         "id":1120,
-         "email":"jane.doe@email.com"
-      },
-      "account":{
-         "id":12345,
-         "email":"john.doe@email.com"
-      }
-    }
-  }`
+		"name":"account.user_remove",
+		"actor": {"pretty": "john.doe@email.com"},
+		"account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+		"data":{
+			"user":{
+				"id":1120,
+				"email":"jane.doe@email.com"
+			},
+			"account":{
+				"id":12345,
+				"email":"john.doe@email.com"
+			}
+		}
+	}`
 	event, err := webhook.ParseEvent([]byte(payload))
 	if err != nil {
 		t.Fatalf("Error parsing: %v.\n%v", err, payload)

--- a/message_test.go
+++ b/message_test.go
@@ -49,6 +49,36 @@ func Test_Message_AccountUserInviteEvent(t *testing.T) {
 	}
 }
 
+func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
+	service := NewTestMessagingService("dummyMessagingService")
+	payload := `{
+    "name":"account.user_invitation_accept",
+    "actor": {"pretty": "xxxxxxxxxxxxxxxxx@xxxxxx.xxx"},
+    "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
+    "data":{
+      "account":{
+        "email":"john.doe@email.com"
+      },
+      "account_invitation":{
+        "email":"jane.doe@email.com",
+        "account_id":12345,
+        "invitation_sent_at":"2020-05-12T18:42:44Z",
+        "invitation_accepted_at":"2020-05-12T18:43:44Z"
+      }
+    }
+  }`
+	event, err := webhook.ParseEvent([]byte(payload))
+	if err != nil {
+		t.Fatalf("Error parsing: %v.\n%v", err, payload)
+	}
+
+	result := Message(service, event)
+
+	if want, got := "jane.doe@email.com accepted invitation to account <12345|https://dnsimple.com/a/12345/account/members>", result; want != got {
+		t.Fatalf("Expected '%v', got '%v'", want, got)
+	}
+}
+
 func Test_Message_DefaultMessage(t *testing.T) {
 	service := NewTestMessagingService("dummyMessagingService")
 	account := webhook.Account{Identifier: "ID", Display: "john.doe@gmail.com"}

--- a/message_test.go
+++ b/message_test.go
@@ -29,6 +29,7 @@ func Test_Message_AccountUserInviteEvent(t *testing.T) {
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data": {
       "account": {
+        "id": 12345,
         "email": "john.doe@email.com"
       },
       "account_invitation": {
@@ -57,6 +58,7 @@ func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data":{
       "account":{
+        "id": 12345,
         "email":"john.doe@email.com"
       },
       "account_invitation":{
@@ -87,6 +89,7 @@ func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
     "account": {"display": "xxxxxxxx", "identifier": "xxxxxxxx"},
     "data":{
       "account":{
+        "id": 12345,
         "email":"john.doe@email.com"
       },
       "account_invitation":{


### PR DESCRIPTION
This PR:
- Introduces tests for the message generation in response to events (adding a test for the default case and the new events introduced in this PR).
- Introduces specific messages for the account membership events:
  - `account.user_invite`
  - `account.user_invitation_accept`
  - `account.user_invitation_revoke`
  - `account.user_remove`

