### PR TITLE
Security Upgrade Golang 1.14.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # Update also: .travis.yml, go.mod (goVersion)
-golang 1.13.8
+golang 1.14.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.13.8"
+  - "1.14.5"
   - tip
 
 matrix:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-// +heroku goVersion go1.13.8
+// +heroku goVersion go1.14.5
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.12
+go 1.14
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079 h1:dm7wU6Dyf+rVGryOAB8/J/I+pYT/9AdG8dstD3kdMWU=
 github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079/go.mod h1:W679Ri2W93VLD8cVpEY/zLH1ow4zhJcCyjzrKxfM3QM=
-github.com/dnsimple/dnsimple-go v0.40.1-0.20200430162822-abe42413c3c3 h1:NIdCy8yXoVnKklMRkD92KFnI68BAhp/Bu21DBn+si+A=
-github.com/dnsimple/dnsimple-go v0.40.1-0.20200430162822-abe42413c3c3/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/dnsimple/dnsimple-go v0.63.0 h1:0doY8VW/ckRIMTmOw4E1vwqo+bhtjDzvh1pU2ZteFGA=
 github.com/dnsimple/dnsimple-go v0.63.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
go1.14.5 (released 2020/07/14) includes security fixes to the crypto/x509 and net/http packages
These issues also exist in go <= 1.13.12

Also runs `go mod tidy`