### PR TITLE
Upgrade to Golang 1.18.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # Update also: .travis.yml, go.mod (goVersion)
-golang 1.14.5
+golang 1.18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: focal
 language: go
 
 go:
-  - "1.14.5"
+  - "1.18.3"
   - tip
 
 matrix:

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,21 @@
-// +heroku goVersion go1.14.5
+// +heroku goVersion go1.18.3
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.14
+go 1.18
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079
 	github.com/dnsimple/dnsimple-go v0.71.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/wunderlist/ttlcache v0.0.0-20180801091818-7dbceb0d5094
+)
+
+require (
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=


### PR DESCRIPTION
This PR upgrades the project to use Golang 1.18.3


# Post Tasks

- [ ] Update documentation in [Go Projects](https://dnsimple.atlassian.net/wiki/spaces/DEV/pages/440139826/Go+Projects)
- [ ] Update documentation in [project page](https://dnsimple.atlassian.net/wiki/spaces/DEV/pages/336658504/Strillone+dnsimple+strillone)
