### PR TITLE
Configure golangci to only alert on new code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,9 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
-        # When entering in a new project, the amount of warnings can be
-        # overwhelming. Fix the stuff, but step by step.
-        continue-on-error: true
         with:
           version: latest
+          only-new-issues: true
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,6 @@ linters:
     - testpackage # Linter that makes you use a separate _test package
     - wastedassign # Finds wasted assignment statements.
     - whitespace # Tool for detection of leading and trailing whitespace
+
+issues:
+    new-from-rev: 1ffac460a0d2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ make test
 make start
 ```
 
+## Go standard tooling
+
+[Go Development Tooling Wiki](https://dnsimple.atlassian.net/wiki/spaces/DEV/pages/440139826/Go+Projects)
 
 ## Go version management
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ start: build
 	overmind start
 
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 fmt:


### PR DESCRIPTION
This PR is a result of a discovery that was made during active development. It configures the linters to only run on new code changes, ensuring we can apply best practices on new code and address existing code wherever we touch it or find the bandwidth to address explicitly.

Discussion: https://dnsimple.slack.com/archives/C02U7FQLB25/p1658877634560709

In addition to this change, instructions have been provided on how to install the required tools for local development.