### PR TITLE
Change/upgrade to golang 1.19.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.18.3"
+  GO_VERSION: "1.19.1"
 
 jobs:
   build:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.18.3
+golang 1.19.1

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-// +heroku goVersion go1.18.3
+// +heroku goVersion go1.19.1
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079

--- a/server.go
+++ b/server.go
@@ -2,7 +2,7 @@ package strillone
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -70,7 +70,7 @@ func (s *Server) Slack(w http.ResponseWriter, r *http.Request, params httprouter
 		return
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		log.Printf("Error parsing body: %v\n", err)


### PR DESCRIPTION
This PR upgrades Golang compiler to 1.19.1

## :mag: QA

- Specs are enough for this

## :shipit: Pre/Post tasks

- [x] **PRE** Make sure herokou has support for 1.19.1
  - https://github.com/heroku/heroku-buildpack-go/pull/496

## :shipit: Verification

- [ ] The SHA has been deployed
- [x] CI has been run against 1.19.1
- [ ] There's no memory issues
