### PR TITLE
Use valid JSON when returning the ping payload

### DIFF
--- a/server.go
+++ b/server.go
@@ -58,7 +58,7 @@ func (s *Server) Root(w http.ResponseWriter, r *http.Request, _ httprouter.Param
 	log.Printf("%s %s\n", r.Method, r.URL.RequestURI())
 	w.Header().Set("Content-type", "application/json")
 
-	fmt.Fprintf(w, `{"ping":"%v","what":"%s"}\n`, time.Now().Unix(), Program)
+	fmt.Fprintf(w, `{"ping":"%v","what":"%s"}`, time.Now().Unix(), Program)
 }
 
 // Slack handles a request to publish a webhook to a Slack channel.


### PR DESCRIPTION
Ending the JSON string in \n is something that may be not valid. This PR fixes this.