### PR TITLE
Upgrade to golang 1.20.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.19.3"
+  GO_VERSION: "1.20.2"
 
 jobs:
   build:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.3
+golang 1.20.2

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-// +heroku goVersion go1.19.3
+// +heroku goVersion go1.20.2
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079


### PR DESCRIPTION
This PR:

- Upgrades Golang version to 1.20.2


## :mag: QA

- Specs are enough for this

## :shipit: Pre/Post tasks

- [ ] Pre: Ensure Heroku has support for 1.20.2
  - https://github.com/heroku/heroku-buildpack-go/pull/511 

## :shipit: Verification

- [ ] The SHA has been deployed
