### PR TITLE
Upgrade to Golang 1.21.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21.1"
+  GO_VERSION: "1.21.5"
 
 jobs:
   build:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.1
+golang 1.21.5

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-// +heroku goVersion go1.21.1
+// +heroku goVersion go1.21.5
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.20
+go 1.21
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079


### PR DESCRIPTION
# Upgrade to Golang 1.21.5

This PR:

- Upgrades Golang version to 1.21.5

## :mag: QA

- Specs are enough for this

## :shipit: Pre/Post tasks

- [x] PRE: https://github.com/heroku/heroku-buildpack-go/pull/531

## :shipit: Verification

- [ ] The SHA has been deployed