### PR TITLE
Upgrade to Golang 1.21.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
-name: CI
+---
+name: ci
 
 on:
   pull_request:
   push:
-    branches: ["main"]
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -14,8 +16,26 @@ env:
   GO_VERSION: "1.21.9"
 
 jobs:
-  build:
-    name: Build
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run YAML Lint
+        uses: actionshub/yamllint@main
+
+  markdownlint-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.3.0
+        with:
+          files: .
+          config_file: ".markdownlint.yaml"
+
+  golangci-lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,33 +48,36 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - run: make build
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+          skip-build-cache: true
 
-  lint:
-    name: Lint
+  build:
     runs-on: ubuntu-latest
-
+    needs:
+      - golangci-lint
+      - markdownlint-cli
+      - yamllint
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: latest
-          skip-pkg-cache: true
-          skip-build-cache: true
+      - run: make build
 
   test:
     name: Test
     runs-on: ubuntu-latest
     needs:
       - build
-      - lint
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21.5"
+  GO_VERSION: "1.21.9"
 
 jobs:
   build:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,16 @@
 linters:
-    enable:
-    - bodyclose # Checks whether HTTP response body is closed successfully
-    - errorlint # Linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exportloopref # Checks for pointers to enclosing loop variables
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gofumpt # Gofumpt checks whether code was gofumpt-ed. Enforces a stricter format than gofmt.
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - misspell # Finds commonly misspelled English words in comments
-    - prealloc # Finds slice declarations that could potentially be preallocated
-    - predeclared # Find code that shadows one of Go's predeclared identifiers
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - testpackage # Linter that makes you use a separate _test package
-    - wastedassign # Finds wasted assignment statements.
-    - whitespace # Tool for detection of leading and trailing whitespace
+  enable:
+    - bodyclose  # Checks whether HTTP response body is closed successfully
+    - errorlint  # Linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - exportloopref  # Checks for pointers to enclosing loop variables
+    - gocritic  # Provides diagnostics that check for bugs, performance and style issues.
+    - gofmt  # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gofumpt  # Gofumpt checks whether code was gofumpt-ed. Enforces a stricter format than gofmt.
+    - goimports  # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
+    - misspell  # Finds commonly misspelled English words in comments
+    - prealloc  # Finds slice declarations that could potentially be preallocated
+    - predeclared  # Find code that shadows one of Go's predeclared identifiers
+    - revive  # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - testpackage  # Linter that makes you use a separate _test package
+    - wastedassign  # Finds wasted assignment statements.
+    - whitespace  # Tool for detection of leading and trailing whitespace

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+---
+default: true
+line-length: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-golang 1.21.5
+# Update also: go.mod .github/workflows/ci.yml
+golang 1.21.9

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+rules:
+  document-start: false
+  line-length:
+    max: 256
+    level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,11 @@ cd ~
 brew install overmind
 ```
 
-
 ## Compilation
 
 ```shell
 make build
 ```
-
 
 ## Testing
 
@@ -45,7 +43,6 @@ To run the test suite:
 ```shell
 make test
 ```
-
 
 ## Running
 
@@ -62,7 +59,6 @@ make start
 The current Go version is defined in the `.tool-versions` file. Contributors are expected to use `asdf` to install and manage Go running environments.
 
 Go modules are enabled. The file `go.mod` MUST include the `go` directive to determine the language feature used by `go` commands.
-
 
 ## Dependency management
 

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Photo: [New York Media](http://nymag.com/daily/intelligencer/2013/06/fed-is-havi
 
 ## License
 
-Copyright (c) 2016-2021 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2016-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@ _Strillone_ is a service to publish the events generated from a DNSimple account
 
 [![Build Status](https://travis-ci.com/dnsimple/strillone.svg?branch=main)](https://travis-ci.com/dnsimple/strillone)
 
-![](img-example.png)
-
+![Example](img-example.png)
 
 ## Usage
 
-#### Deploy the application
+### Deploy the application
 
 You can use the following button to deploy the service to Heroku.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/dnsimple/strillone)
 
-#### Check the deploy
+### Check the deploy
 
 Make sure the app is properly deployed. If you access the homepage, you should see a JSON response like the following one:
 
@@ -23,7 +22,7 @@ Make sure the app is properly deployed. If you access the homepage, you should s
 {"ping":"1458412047","what":"dnsimple-strillone"}
 ```
 
-#### Configure the Publishers
+### Configure the Publishers
 
 Configure the target of the messages. We currently support the following publishers:
 
@@ -31,10 +30,9 @@ Configure the target of the messages. We currently support the following publish
 
 See below for the specific configurations.
 
-#### Create the webhook
+### Create the webhook
 
 Once you configured the publisher and generated the webhook URL, use the URL to create a new webhook in your DNSimple account.
-
 
 ## Slack configuration
 
@@ -42,31 +40,29 @@ Strillone integrates with Slack using the [Slack Incoming Webhook](https://api.s
 
 First, you need to [setup an incoming webhook](https://my.slack.com/services/new/incoming-webhook/). Select the Slack channel and follow the instructions.
 
-![](img-config-1.png)
+![Config 1](img-config-1.png)
 
 Once created, Slack will give you a _Webhook URL_ that looks like the following one:
 
-![](img-config-2.png)
+![Config 2](img-config-2.png)
 
 To generate the Strillone webhook URL, simply replace the initial fixed part of the Slack webhook URL with `https://your-strillone-domain.com/slack`.
 
 For instance, if your Heroku app is `https://happy-panda.herokuapp.com/` and the Slack webhook URL is `https://hooks.slack.com/services/XXXXX/YYYYY/ZZZZZZZZZZ`, then your Strillone webhook URL for this specific integration will be:
 
-```
+```bash
 https://your-strillone-domain.com/slack/XXXXX/YYYYY/ZZZZZZZZZZ
 ```
 
 This is the URL you have to enter in DNSimple when creating the webhook.
 
-
 ## About the name
 
 The word [strillone](https://en.wiktionary.org/wiki/strillone) (literally _someone who shouts a lot_, in practice the equivalent of _newspaper boy_) comes from Italian and it refers to the newspaper sellers in the street, who were used to yell the titles in the front page to catch the attention and sell more newspapers.
 
-![](strillone.jpg)
+![Strillone](strillone.jpg)
 
 Photo: [New York Media](http://nymag.com/daily/intelligencer/2013/06/fed-is-having-a-1936-moment.html)
-
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// +heroku goVersion go1.21.5
+// +heroku goVersion go1.21.9
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone


### PR DESCRIPTION
# Upgrade to Golang 1.21.9

This PR:

- Upgrades Golang version to 1.21.9
- Also adds Yaml and Markdown linters

## :mag: QA

- Specs are enough for this

## :shipit: Pre/Post tasks

- [ ] Post: Update docs

## :shipit: Verification

- [ ] The SHA has been deployed
