### PR TITLE
Upgrade Go version to 1.24.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GO_VERSION: "1.23.2"
-
 jobs:
   yamllint:
     runs-on: ubuntu-latest
@@ -33,7 +30,7 @@ jobs:
         uses: nosborn/github-action-markdown-cli@v3.4.0
         with:
           files: .
-          config_file: ".markdownlint.yaml"
+          config_file: '.markdownlint.yaml'
 
   golangci-lint:
     runs-on: ubuntu-latest
@@ -45,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - name: golangci-lint
@@ -68,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - run: make build
@@ -84,7 +81,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,16 @@
 linters:
   enable:
-    - bodyclose  # Checks whether HTTP response body is closed successfully
-    - errorlint  # Linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exportloopref  # Checks for pointers to enclosing loop variables
-    - gocritic  # Provides diagnostics that check for bugs, performance and style issues.
-    - gofmt  # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gofumpt  # Gofumpt checks whether code was gofumpt-ed. Enforces a stricter format than gofmt.
-    - goimports  # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - misspell  # Finds commonly misspelled English words in comments
-    - prealloc  # Finds slice declarations that could potentially be preallocated
-    - predeclared  # Find code that shadows one of Go's predeclared identifiers
-    - revive  # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - testpackage  # Linter that makes you use a separate _test package
-    - wastedassign  # Finds wasted assignment statements.
-    - whitespace  # Tool for detection of leading and trailing whitespace
+    - bodyclose # Checks whether HTTP response body is closed successfully
+    - errorlint # Linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - copyloopvar # Checks for pointers to enclosing loop variables
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gofumpt # Gofumpt checks whether code was gofumpt-ed. Enforces a stricter format than gofmt.
+    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
+    - misspell # Finds commonly misspelled English words in comments
+    - prealloc # Finds slice declarations that could potentially be preallocated
+    - predeclared # Find code that shadows one of Go's predeclared identifiers
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - testpackage # Linter that makes you use a separate _test package
+    - wastedassign # Finds wasted assignment statements.
+    - whitespace # Tool for detection of leading and trailing whitespace

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 # Update also: go.mod .github/workflows/ci.yml
-golang 1.23.2
+golang 1.24.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,1 @@
-# Update also: go.mod .github/workflows/ci.yml
 golang 1.24.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/dnsimple/strillone
 
-go 1.23.2
+go 1.24.1
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079
@@ -18,6 +18,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/oauth2 v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// +heroku goVersion go1.23.2
+// +heroku goVersion go1.24.1
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wunderlist/ttlcache v0.0.0-20180801091818-7dbceb0d5094 h1:SKfd0IzhLdnCU0v/Qj7inYUUejGdFP2/24mB9DXT/G8=
 github.com/wunderlist/ttlcache v0.0.0-20180801091818-7dbceb0d5094/go.mod h1:oWWm4B/FRe5AKcl+/5tz6YaA4HWpzzt5hSKM5+LSYgM=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
+golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Overview

Upgrade Go version to 1.24.1

## Changes

- Update Go version to 1.24.1 in project configuration files
- Update module dependencies


Belongs to dnsimple/dnsimple-engineering#274