### PR TITLE
Refactor project structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	go test -v ./...
 
 build:
-	go build -ldflags "-X main.Version=$$(git rev-parse --short HEAD)" -o bin/strillone cmd/strillone/*.go
+	go build -o bin/strillone cmd/strillone/*.go
 
 clean:
 	rm bin/strillone

--- a/cmd/strillone/main.go
+++ b/cmd/strillone/main.go
@@ -3,31 +3,27 @@ package main
 import (
 	"log"
 	"net/http"
-	"os"
 
+	"github.com/dnsimple/strillone/internal/config"
 	xhttp "github.com/dnsimple/strillone/internal/http"
 )
 
 var (
-	// Program name
-	Program = "dnsimple-strillone"
-
 	// Version is replaced at compilation time
 	Version string
 )
 
 func main() {
-	log.Printf("Starting %s/%s\n", Program, Version)
-
-	httpPort := os.Getenv("PORT")
-	if httpPort == "" {
-		httpPort = "4000"
+	cfg, err := config.NewConfig()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
 	}
+	config.Config = cfg
 
 	server := xhttp.NewServer()
 
-	log.Printf("%s listening on %s...\n", Program, httpPort)
-	if err := http.ListenAndServe(":"+httpPort, server); err != nil {
+	log.Printf("%s listening on %s...\n", config.Program, cfg.Port)
+	if err := http.ListenAndServe(":"+cfg.Port, server); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/cmd/strillone/main.go
+++ b/cmd/strillone/main.go
@@ -8,10 +8,8 @@ import (
 	xhttp "github.com/dnsimple/strillone/internal/http"
 )
 
-var (
-	// Version is replaced at compilation time
-	Version string
-)
+// Version is replaced at compilation time
+var Version string
 
 func main() {
 	cfg, err := config.NewConfig()

--- a/cmd/strillone/main.go
+++ b/cmd/strillone/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/dnsimple/strillone"
+	xhttp "github.com/dnsimple/strillone/internal/http"
 )
 
 var (
@@ -24,7 +24,7 @@ func main() {
 		httpPort = "4000"
 	}
 
-	server := strillone.NewServer()
+	server := xhttp.NewServer()
 
 	log.Printf("%s listening on %s...\n", Program, httpPort)
 	if err := http.ListenAndServe(":"+httpPort, server); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ module github.com/dnsimple/strillone
 go 1.24.1
 
 require (
+	github.com/caarlos0/env/v11 v11.3.1
 	github.com/dnsimple/dnsimple-go v1.7.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/slack-go/slack v0.16.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/caarlos0/env/v11 v11.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,20 +6,20 @@ module github.com/dnsimple/strillone
 go 1.24.1
 
 require (
-	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079
 	github.com/dnsimple/dnsimple-go v1.7.0
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/slack-go/slack v0.16.0
 	github.com/stretchr/testify v1.10.0
 	github.com/wunderlist/ttlcache v0.0.0-20180801091818-7dbceb0d5094
 )
 
 require (
+	github.com/caarlos0/env/v11 v11.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/slack-go/slack v0.16.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
-github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079 h1:dm7wU6Dyf+rVGryOAB8/J/I+pYT/9AdG8dstD3kdMWU=
-github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079/go.mod h1:W679Ri2W93VLD8cVpEY/zLH1ow4zhJcCyjzrKxfM3QM=
+github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
+github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnsimple/dnsimple-go v1.7.0 h1:JKu9xJtZ3SqOC+BuYgAWeab7+EEx0sz422vu8j611ZY=
 github.com/dnsimple/dnsimple-go v1.7.0/go.mod h1:EKpuihlWizqYafSnQHGCd/gyvy3HkEQJ7ODB4KdV8T8=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"github.com/caarlos0/env/v11"
+)
+
+var (
+	// Config is the global configuration
+	Config *AppConfig
+
+	// Program name
+	Program = "dnsimple-strillone"
+)
+
+// AppConfig represents the configuration of the application.
+type AppConfig struct {
+	// Port is the HTTP port the server listens on.
+	Port string `env:"PORT" envDefault:"4000"`
+	// DNSimpleUrl is the DNSimple app URL.
+	DNSimpleUrl string `env:"DNSIMPLE_URL" envDefault:"https://dnsimple.com"`
+}
+
+// NewConfig returns a new AppConfig instance.
+func NewConfig() (*AppConfig, error) {
+	cfg := &AppConfig{}
+	if err := env.Parse(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,8 @@ var (
 type AppConfig struct {
 	// Port is the HTTP port the server listens on.
 	Port string `env:"PORT" envDefault:"4000"`
-	// DNSimpleUrl is the DNSimple app URL.
-	DNSimpleUrl string `env:"DNSIMPLE_URL" envDefault:"https://dnsimple.com"`
+	// DNSimpleURL is the DNSimple app URL.
+	DNSimpleURL string `env:"DNSIMPLE_URL" envDefault:"https://dnsimple.com"`
 }
 
 // NewConfig returns a new AppConfig instance.

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,4 +1,4 @@
-package strillone
+package http
 
 import (
 	"fmt"
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
+	"github.com/dnsimple/strillone/internal/service"
 	"github.com/julienschmidt/httprouter"
 	"github.com/wunderlist/ttlcache"
 )
 
 const (
-	dnsimpleURL            = "https://dnsimple.com"
 	cacheTTL               = 300
 	HeaderProcessingStatus = "X-Processing-Status"
 )
@@ -96,7 +96,7 @@ func (s *Server) Slack(w http.ResponseWriter, r *http.Request, params httprouter
 	slackAlpha, slackBeta, slackGamma := params.ByName("slackAlpha"), params.ByName("slackBeta"), params.ByName("slackGamma")
 	slackToken := fmt.Sprintf("%s/%s/%s", slackAlpha, slackBeta, slackGamma)
 
-	service := &SlackService{Token: slackToken}
+	service := &service.SlackService{Token: slackToken}
 	text, err := service.PostEvent(event)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -1,4 +1,4 @@
-package strillone_test
+package http_test
 
 import (
 	"net/http"
@@ -6,15 +6,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dnsimple/strillone"
+	appServer "github.com/dnsimple/strillone/internal/http"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
 )
 
-var server *strillone.Server
+var server *appServer.Server
 
 func init() {
-	server = strillone.NewServer()
+	server = appServer.NewServer()
 }
 
 func TestRoot(t *testing.T) {
@@ -52,7 +52,7 @@ func TestSlackTwice(t *testing.T) {
 	if want := http.StatusOK; want != response.Code {
 		t.Errorf("POST /slack expected HTTP %v, got %v", want, response.Code)
 	}
-	assert.Empty(t, response.Header().Get(strillone.HeaderProcessingStatus))
+	assert.Empty(t, response.Header().Get(appServer.HeaderProcessingStatus))
 
 	requestDuplicate, _ := http.NewRequest("POST", "/slack/-/-/-", strings.NewReader(payload))
 	responseDuplicate := httptest.NewRecorder()
@@ -60,5 +60,5 @@ func TestSlackTwice(t *testing.T) {
 	server.Slack(responseDuplicate, requestDuplicate, httprouter.Params{})
 
 	assert.Equal(t, http.StatusOK, response.Code)
-	assert.Equal(t, "skipped;already-processed", responseDuplicate.Header().Get(strillone.HeaderProcessingStatus))
+	assert.Equal(t, "skipped;already-processed", responseDuplicate.Header().Get(appServer.HeaderProcessingStatus))
 }

--- a/internal/http/server_test.go
+++ b/internal/http/server_test.go
@@ -1,11 +1,14 @@
 package http_test
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/dnsimple/strillone/internal/config"
 	appServer "github.com/dnsimple/strillone/internal/http"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +18,22 @@ var server *appServer.Server
 
 func init() {
 	server = appServer.NewServer()
+}
+
+func TestMain(m *testing.M) {
+	// Load configuration here
+	// This ensures configuration is available before any tests run
+	cfg, err := config.NewConfig()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+	config.Config = cfg
+
+	// Run the tests
+	exitCode := m.Run()
+
+	// Exit with the same code
+	os.Exit(exitCode)
 }
 
 func TestRoot(t *testing.T) {

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -1,10 +1,14 @@
-package strillone
+package service
 
 import (
 	"fmt"
 	"strings"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
+)
+
+const (
+	dnsimpleURL = "https://dnsimple.com"
 )
 
 // Message formats the event into a text message suitable for being sent to a messaging service.

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -5,10 +5,7 @@ import (
 	"strings"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
-)
-
-const (
-	dnsimpleURL = "https://dnsimple.com"
+	"github.com/dnsimple/strillone/internal/config"
 )
 
 // Message formats the event into a text message suitable for being sent to a messaging service.
@@ -167,5 +164,5 @@ func eventRequestID(e *webhook.Event) string {
 }
 
 func FmtURL(path string, a ...interface{}) string {
-	return fmt.Sprintf(dnsimpleURL+path, a...)
+	return fmt.Sprintf(config.Config.DNSimpleUrl+path, a...)
 }

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -164,5 +164,5 @@ func eventRequestID(e *webhook.Event) string {
 }
 
 func FmtURL(path string, a ...interface{}) string {
-	return fmt.Sprintf(config.Config.DNSimpleUrl+path, a...)
+	return fmt.Sprintf(config.Config.DNSimpleURL+path, a...)
 }

--- a/internal/service/message_test.go
+++ b/internal/service/message_test.go
@@ -1,11 +1,11 @@
-package strillone_test
+package service_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
-	"github.com/dnsimple/strillone"
+	strillone "github.com/dnsimple/strillone/internal/service"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/service/message_test.go
+++ b/internal/service/message_test.go
@@ -2,12 +2,31 @@ package service_test
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
-	strillone "github.com/dnsimple/strillone/internal/service"
+	"github.com/dnsimple/strillone/internal/config"
+	xservice "github.com/dnsimple/strillone/internal/service"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	// Load configuration here
+	// This ensures configuration is available before any tests run
+	cfg, err := config.NewConfig()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+	config.Config = cfg
+
+	// Run the tests
+	exitCode := m.Run()
+
+	// Exit with the same code
+	os.Exit(exitCode)
+}
 
 type TestMessagingService struct {
 	Name string
@@ -45,7 +64,7 @@ func Test_Message_AccountUserInviteEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "john.doe@email.com invited jane.doe@email.com to account <12345|https://dnsimple.com/a/12345/account/members>", result)
 }
 
@@ -71,7 +90,7 @@ func Test_Message_AccountUserInvitationAcceptEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "jane.doe@email.com accepted invitation to account <12345|https://dnsimple.com/a/12345/account/members>", result)
 }
 
@@ -97,7 +116,7 @@ func Test_Message_AccountUserInvitationRevokeEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "jane.doe@email.com rejected invitation to account <12345|https://dnsimple.com/a/12345/account/members>", result)
 }
 
@@ -121,7 +140,7 @@ func Test_Message_AccountUserRemoveEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "john.doe@email.com removed jane.doe@email.com from account <12345|https://dnsimple.com/a/12345/account/members>", result)
 }
 
@@ -131,7 +150,7 @@ func Test_Message_DomainTransferLockDisableEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "[<xxxxxxx-xxxxxxx-xxxxxxx|https://dnsimple.com/a/1010/account>] xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com disabled transfer lock for the domain <example.com|https://dnsimple.com/a/1010/domains/example.com>", result)
 }
 
@@ -141,7 +160,7 @@ func Test_Message_DomainTransferLockEnableEvent(t *testing.T) {
 	event, err := webhook.ParseEvent([]byte(payload))
 	assert.NoError(t, err)
 
-	result := strillone.Message(service, event)
+	result := xservice.Message(service, event)
 	assert.Equal(t, "[<xxxxxxx-xxxxxxx-xxxxxxx|https://dnsimple.com/a/1010/account>] xxxxxxx-xxxxxxx-xxxxxxx@xxxxx.com enabled transfer lock for the domain <example.com|https://dnsimple.com/a/1010/domains/example.com>", result)
 }
 
@@ -151,10 +170,10 @@ func Test_Message_DefaultMessage(t *testing.T) {
 	actor := webhook.Actor{Pretty: "john.doe@email.com"}
 	event := webhook.Event{Actor: &actor, Account: &account, Name: "event.name"}
 
-	result := strillone.Message(service, &event)
+	result := xservice.Message(service, &event)
 	assert.Equal(t, "[<john.doe@gmail.com|https://dnsimple.com/a/0/account>] john.doe@email.com performed event.name", result)
 }
 
 func Test_fmtURL(t *testing.T) {
-	assert.Equal(t, "https://dnsimple.com/a/1010/domains/1", strillone.FmtURL("/a/%v/domains/%v", "1010", 1))
+	assert.Equal(t, "https://dnsimple.com/a/1010/domains/1", xservice.FmtURL("/a/%v/domains/%v", "1010", 1))
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,4 +1,4 @@
-package strillone
+package service
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Adopt best practices for the project's structure by moving our code to `internal/**/*`.

- Added config via `github.com/caarlos0/env/v11` package.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/271