### PR TITLE
Move Version and Program to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build
 
 .PHONY: build
 build:
-	go build -ldflags "-X config.Version=$(PKG_VERSION)" -o bin/strillone cmd/strillone/*.go
+	go build -ldflags "-X github.com/dnsimple/strillone/internal/config.Version=$(PKG_VERSION)" -o bin/strillone cmd/strillone/*.go
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build
 
 .PHONY: build
 build:
-	go build -ldflags "-X main.Version=$(PKG_VERSION)" -o bin/strillone cmd/strillone/*.go
+	go build -ldflags "-X config.Version=$(PKG_VERSION)" -o bin/strillone cmd/strillone/*.go
 
 .PHONY: clean
 clean:

--- a/cmd/strillone/main.go
+++ b/cmd/strillone/main.go
@@ -8,9 +8,6 @@ import (
 	xhttp "github.com/dnsimple/strillone/internal/http"
 )
 
-// Version is replaced at compilation time
-var Version string
-
 func main() {
 	cfg, err := config.NewConfig()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,9 @@ var (
 
 	// Program name
 	Program = "dnsimple-strillone"
+
+	// Version is replaced at compilation time
+	Version string
 )
 
 // AppConfig represents the configuration of the application.

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"github.com/dnsimple/strillone/internal/config"
 	"io"
 	"log"
 	"net/http"
@@ -16,14 +17,6 @@ import (
 const (
 	cacheTTL               = 300
 	HeaderProcessingStatus = "X-Processing-Status"
-)
-
-var (
-	// Program name
-	Program = "dnsimple-strillone"
-
-	// Version is replaced at compilation time
-	Version string
 )
 
 // Server represents a front-end web server.
@@ -58,7 +51,7 @@ func (s *Server) Root(w http.ResponseWriter, r *http.Request, _ httprouter.Param
 	log.Printf("%s %s\n", r.Method, r.URL.RequestURI())
 	w.Header().Set("Content-type", "application/json")
 
-	fmt.Fprintf(w, `{"ping":"%v","what":"%s"}`, time.Now().Unix(), Program)
+	fmt.Fprintf(w, `{"ping":"%v","what":"%s"}`, time.Now().Unix(), config.Program)
 }
 
 // Slack handles a request to publish a webhook to a Slack channel.

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -2,13 +2,13 @@ package http
 
 import (
 	"fmt"
-	"github.com/dnsimple/strillone/internal/config"
 	"io"
 	"log"
 	"net/http"
 	"time"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple/webhook"
+	"github.com/dnsimple/strillone/internal/config"
 	"github.com/dnsimple/strillone/internal/service"
 	"github.com/julienschmidt/httprouter"
 	"github.com/wunderlist/ttlcache"


### PR DESCRIPTION
## Description

In a recent PR, [the refactoring broke the `ldflags`](https://github.com/dnsimple/strillone/pull/59) that was setting up the version.

I fixed it, and took the opportunity to move `Version` and `Program` consistently in the config, removing the duplicates.

## Notes

We used to define `Version` in the main binary, but it actually made sense to me that we would do it in the shared config so that all code had access to it.

I searched a bit, and I found that's actually a quite common approach:

> Here are some examples of notable Go projects using `ldflags` to set version information in subpackages rather than the main package:
> 
> 1. **Kubernetes**
>    Kubernetes uses a dedicated version package:
>    ```bash
>    go build -ldflags "-X k8s.io/kubernetes/pkg/version.gitVersion=${VERSION} 
>                       -X k8s.io/kubernetes/pkg/version.gitCommit=${COMMIT} 
>                       -X k8s.io/kubernetes/pkg/version.buildDate=${BUILD_DATE}"
>    ```
> 
> 2. **Docker**
>    Docker uses a version package:
>    ```bash
>    go build -ldflags "-X github.com/docker/docker/cli/version.Version=${VERSION} 
>                       -X github.com/docker/docker/cli/version.GitCommit=${COMMIT} 
>                       -X github.com/docker/docker/cli/version.BuildTime=${BUILD_TIME}"
>    ```
> 
> 3. **Hugo**
>    Hugo sets version info in a dedicated package:
>    ```bash
>    go build -ldflags "-X github.com/gohugoio/hugo/common/hugo.commitHash=${COMMIT_HASH} 
>                       -X github.com/gohugoio/hugo/common/hugo.buildDate=${BUILD_DATE}"
>    ```
> 
> 4. **Prometheus**
>    Prometheus has a separate version package:
>    ```bash
>    go build -ldflags "-X github.com/prometheus/common/version.Version=${VERSION} 
>                       -X github.com/prometheus/common/version.Revision=${REVISION} 
>                       -X github.com/prometheus/common/version.Branch=${BRANCH} 
>                       -X github.com/prometheus/common/version.BuildUser=${USER}"
>    ```
> 
> 5. **Terraform**
>    Terraform uses a version package:
>    ```bash
>    go build -ldflags "-X github.com/hashicorp/terraform/version.Version=${VERSION} 
>                       -X github.com/hashicorp/terraform/version.Prerelease=${PRERELEASE}"
>    ```
> 
> These examples demonstrate a common pattern where large Go projects use a dedicated package (often named `version` or within a `common` package) to hold version information that can be modified at build time using ldflags.