### PR TITLE
Chore: Bump to go 1.24.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.24.1
+golang 1.24.4

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-// +heroku goVersion go1.24.1
+// +heroku goVersion go1.24.4
 // +heroku install ./cmd/...
 
 module github.com/dnsimple/strillone
 
-go 1.24.1
+go 1.24.4
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1


### PR DESCRIPTION
Minor patch to the Go version.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/271