### PR TITLE
Handle zone delete event

### DIFF
--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -140,6 +140,14 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 			text = fmt.Sprintf("%s renewed whois privacy for the domain %s", prefix, domainLink)
 		}
 
+	case *webhook.ZoneEventData:
+		zoneDisplay := data.Zone.Name
+		zoneLink := s.FormatLink(zoneDisplay, FmtURL("/a/%d/domains/%s", account.ID, data.Zone.Name))
+		switch e.Name {
+		case "zone.delete":
+			text = fmt.Sprintf("%s deleted the zone %s", prefix, zoneLink)
+		}
+
 	case *webhook.ZoneRecordEventData:
 		zoneRecordDisplay := fmt.Sprintf("%s %s.%s %s", data.ZoneRecord.Type, data.ZoneRecord.Name, data.ZoneRecord.ZoneID, data.ZoneRecord.Content)
 		zoneRecordLink := s.FormatLink(zoneRecordDisplay, FmtURL("/a/%d/domains/%s/records/%d", account.ID, data.ZoneRecord.ZoneID, data.ZoneRecord.ID))

--- a/internal/service/message.go
+++ b/internal/service/message.go
@@ -143,8 +143,7 @@ func Message(s MessagingService, e *webhook.Event) (text string) {
 	case *webhook.ZoneEventData:
 		zoneDisplay := data.Zone.Name
 		zoneLink := s.FormatLink(zoneDisplay, FmtURL("/a/%d/domains/%s", account.ID, data.Zone.Name))
-		switch e.Name {
-		case "zone.delete":
+		if e.Name == "zone.delete" {
 			text = fmt.Sprintf("%s deleted the zone %s", prefix, zoneLink)
 		}
 


### PR DESCRIPTION
This PR adds the message handler for the `zone.delete` message, which is currently falling into the generic case:

<img width="2168" height="486" alt="Screenshot 2025-08-13 at 14 37 08" src="https://github.com/user-attachments/assets/1ee5ef03-a8c4-4988-bf70-cf00c9f5e574" />
